### PR TITLE
Add support for existing chunk names

### DIFF
--- a/__tests__/__snapshots__/index.js.snap
+++ b/__tests__/__snapshots__/index.js.snap
@@ -60,7 +60,27 @@ _universalImport({
 "
 `;
 
-exports[`4. static import (string template) 1`] = `
+exports[`4. static import (with magic comment) 1`] = `
+"
+import(/* webpackChunkName: \\"notfoo\\" */ \\"./Foo\\")
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import _path from \\"path\\";
+import _importCss from \\"babel-plugin-universal-import/importCss.js\\";
+import _universalImport from \\"babel-plugin-universal-import/universalImport.js\\";
+_universalImport({
+  id: \\"./Foo\\",
+  file: \\"currentFile.js\\",
+  load: () => Promise.all([import( /* webpackChunkName: 'notfoo' */\\"./Foo\\"), _importCss(\\"Foo\\")]).then(proms => proms[0]),
+  path: () => _path.join(__dirname, \\"./Foo\\"),
+  resolve: () => require.resolveWeak(\\"./Foo\\"),
+  chunkName: () => \\"notfoo\\"
+});
+"
+`;
+
+exports[`5. static import (string template) 1`] = `
 "
 import(\`./base\`)
 
@@ -80,7 +100,7 @@ _universalImport({
 "
 `;
 
-exports[`5. static import (string template + relative paths) 1`] = `
+exports[`6. static import (string template + relative paths) 1`] = `
 "
 import(\`../../base\`)
 
@@ -100,7 +120,7 @@ _universalImport({
 "
 `;
 
-exports[`6. dynamic import (string template) 1`] = `
+exports[`7. dynamic import (string template) 1`] = `
 "
 import(\`./base/\${page}\`)
 
@@ -120,7 +140,27 @@ _universalImport({
 "
 `;
 
-exports[`7. dynamic import (string template - dynamic at 1st segment) 1`] = `
+exports[`8. dynamic import (with magic comment) 1`] = `
+"
+import(/* webpackChunkName: \\"notfoo\\" */ \`./base/\${page}\`)
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import _path from \\"path\\";
+import _importCss from \\"babel-plugin-universal-import/importCss.js\\";
+import _universalImport from \\"babel-plugin-universal-import/universalImport.js\\";
+_universalImport({
+  id: \\"./base/\${page}\\",
+  file: \\"currentFile.js\\",
+  load: () => Promise.all([import( /* webpackChunkName: 'notfoo' */\`./base/\${page}\`), _importCss(\`base/\${page}\`)]).then(proms => proms[0]),
+  path: () => _path.join(__dirname, \`./base/\${page}\`),
+  resolve: () => require.resolveWeak(\`./base/\${page}\`),
+  chunkName: () => \\"notfoo\\"
+});
+"
+`;
+
+exports[`9. dynamic import (string template - dynamic at 1st segment) 1`] = `
 "
 import(\`./\${page}\`)
 
@@ -140,7 +180,7 @@ _universalImport({
 "
 `;
 
-exports[`8. dynamic import (string template + relative paths) 1`] = `
+exports[`10. dynamic import (string template + relative paths) 1`] = `
 "
 import(\`../../base/\${page}\`)
 
@@ -160,7 +200,7 @@ _universalImport({
 "
 `;
 
-exports[`9. await import() should receive a thennable without calling .then 1`] = `
+exports[`11. await import() should receive a thennable without calling .then 1`] = `
 "
 async ({ page }) => await import(\`../components/\${page}\`);
 
@@ -172,7 +212,7 @@ async ({ page }) => await _universalImport(() => Promise.all([import( /* webpack
 "
 `;
 
-exports[`10. babelServer: true 1`] = `
+exports[`12. babelServer: true 1`] = `
 "
 import(\\"./Foo\\")
 

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -21,9 +21,13 @@ pluginTester({
     'static import': 'import("./Foo")',
     'static import (with relative paths)': 'import("../../Foo")',
     'static import (with file extension)': 'import("./Foo.js")',
+    'static import (with magic comment)':
+      'import(/* webpackChunkName: "notfoo" */ "./Foo")',
     'static import (string template)': 'import(`./base`)',
     'static import (string template + relative paths)': 'import(`../../base`)',
     'dynamic import (string template)': 'import(`./base/${page}`)',
+    'dynamic import (with magic comment)':
+      'import(/* webpackChunkName: "notfoo" */ `./base/${page}`)',
     'dynamic import (string template - dynamic at 1st segment)':
       'import(`./${page}`)',
     'dynamic import (string template + relative paths)':

--- a/package.json
+++ b/package.json
@@ -59,5 +59,7 @@
       "git add"
     ]
   },
-  "dependencies": {}
+  "dependencies": {
+    "json5": "^0.5.1"
+  }
 }


### PR DESCRIPTION
It wasn't too bad to add the support.

One concern might be the dependency. As documented, webpack parses the magic comments using `JSON5`. See: https://webpack.js.org/api/module-methods/#import-

If there is some syntax you'd prefer other then using magic comments, I'd be for it. Adding a second argument to `import` seems a little presumptuous, but it'd do the job.

Solves https://github.com/faceyspacey/babel-plugin-universal-import/issues/10