### PR TITLE
fix($chunkNames): Fix a bug using dynamic imports with nested folders

### DIFF
--- a/__tests__/__snapshots__/index.js.snap
+++ b/__tests__/__snapshots__/index.js.snap
@@ -120,7 +120,27 @@ _universalImport({
 "
 `;
 
-exports[`7. dynamic import (string template - dynamic at 1st segment) 1`] = `
+exports[`7. dynamic import (string template with nested folder) 1`] = `
+"
+import(\`./base/\${page}/nested/folder\`)
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import _path from \\"path\\";
+import _importCss from \\"babel-plugin-universal-import/importCss.js\\";
+import _universalImport from \\"babel-plugin-universal-import/universalImport.js\\";
+_universalImport({
+  id: \\"./base/\${page}/nested/folder\\",
+  file: \\"currentFile.js\\",
+  load: () => Promise.all([import( /* webpackChunkName: 'base/[request]' */\`./base/\${page}/nested/folder\`), _importCss(\`base/\${page}-nested-folder\`)]).then(proms => proms[0]),
+  path: () => _path.join(__dirname, \`./base/\${page}/nested/folder\`),
+  resolve: () => require.resolveWeak(\`./base/\${page}/nested/folder\`),
+  chunkName: () => \`base/\${page}-nested-folder\`
+});
+"
+`;
+
+exports[`8. dynamic import (string template - dynamic at 1st segment) 1`] = `
 "
 import(\`./\${page}\`)
 
@@ -140,7 +160,7 @@ _universalImport({
 "
 `;
 
-exports[`8. dynamic import (string template + relative paths) 1`] = `
+exports[`9. dynamic import (string template + relative paths) 1`] = `
 "
 import(\`../../base/\${page}\`)
 
@@ -160,7 +180,7 @@ _universalImport({
 "
 `;
 
-exports[`9. await import() should receive a thennable without calling .then 1`] = `
+exports[`10. await import() should receive a thennable without calling .then 1`] = `
 "
 async ({ page }) => await import(\`../components/\${page}\`);
 
@@ -172,7 +192,7 @@ async ({ page }) => await _universalImport(() => Promise.all([import( /* webpack
 "
 `;
 
-exports[`10. babelServer: true 1`] = `
+exports[`11. babelServer: true 1`] = `
 "
 import(\\"./Foo\\")
 

--- a/__tests__/__snapshots__/index.js.snap
+++ b/__tests__/__snapshots__/index.js.snap
@@ -140,7 +140,27 @@ _universalImport({
 "
 `;
 
-exports[`8. dynamic import (string template - dynamic at 1st segment) 1`] = `
+exports[`8. dynamic import (string template with multiple nested folders) 1`] = `
+"
+import(\`./base/\${page}/nested/{$another}folder\`)
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import _path from \\"path\\";
+import _importCss from \\"babel-plugin-universal-import/importCss.js\\";
+import _universalImport from \\"babel-plugin-universal-import/universalImport.js\\";
+_universalImport({
+  id: \\"./base/\${page}/nested/{$another}folder\\",
+  file: \\"currentFile.js\\",
+  load: () => Promise.all([import( /* webpackChunkName: 'base/[request]' */\`./base/\${page}/nested/{$another}folder\`), _importCss(\`base/\${page}-nested-{$another}folder\`)]).then(proms => proms[0]),
+  path: () => _path.join(__dirname, \`./base/\${page}/nested/{$another}folder\`),
+  resolve: () => require.resolveWeak(\`./base/\${page}/nested/{$another}folder\`),
+  chunkName: () => \`base/\${page}-nested-{$another}folder\`
+});
+"
+`;
+
+exports[`9. dynamic import (string template - dynamic at 1st segment) 1`] = `
 "
 import(\`./\${page}\`)
 
@@ -160,7 +180,7 @@ _universalImport({
 "
 `;
 
-exports[`9. dynamic import (string template + relative paths) 1`] = `
+exports[`10. dynamic import (string template + relative paths) 1`] = `
 "
 import(\`../../base/\${page}\`)
 
@@ -180,7 +200,7 @@ _universalImport({
 "
 `;
 
-exports[`10. await import() should receive a thennable without calling .then 1`] = `
+exports[`11. await import() should receive a thennable without calling .then 1`] = `
 "
 async ({ page }) => await import(\`../components/\${page}\`);
 
@@ -192,7 +212,7 @@ async ({ page }) => await _universalImport(() => Promise.all([import( /* webpack
 "
 `;
 
-exports[`11. babelServer: true 1`] = `
+exports[`12. babelServer: true 1`] = `
 "
 import(\\"./Foo\\")
 

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -24,6 +24,8 @@ pluginTester({
     'static import (string template)': 'import(`./base`)',
     'static import (string template + relative paths)': 'import(`../../base`)',
     'dynamic import (string template)': 'import(`./base/${page}`)',
+    'dynamic import (string template with nested folder)':
+      'import(`./base/${page}/nested/folder`)',
     'dynamic import (string template - dynamic at 1st segment)':
       'import(`./${page}`)',
     'dynamic import (string template + relative paths)':

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -26,6 +26,8 @@ pluginTester({
     'dynamic import (string template)': 'import(`./base/${page}`)',
     'dynamic import (string template with nested folder)':
       'import(`./base/${page}/nested/folder`)',
+    'dynamic import (string template with multiple nested folders)':
+      'import(`./base/${page}/nested/{$another}folder`)',
     'dynamic import (string template - dynamic at 1st segment)':
       'import(`./${page}`)',
     'dynamic import (string template + relative paths)':
@@ -43,7 +45,8 @@ pluginTester({
 test.skip('wallaby-live-coding', () => {
   // const input = 'async ({ page }) => await import(`../components/${page}`);'
   // const input = 'import("../../Foo.js")'
-  const input = 'universal(props => import(`./footer/${props.experiment}`));'
+  // const input = 'universal(props => import(`./footer/${props.experiment}`));'
+  const input = 'import(`./base/${page}/index`)'
 
   const output = babel.transform(input, {
     filename: 'currentFile.js',

--- a/index.js
+++ b/index.js
@@ -21,6 +21,10 @@ module.exports = function ({ types: t, template }) {
     return baseDir.replace(/^[./]+|(\.js$)/g, '')
   }
 
+  function prepareChunkNamePath(path) {
+    return path.replace(/\//g, '-')
+  }
+
   function getUniversalImport(p) {
     if (!p.hub.file[universalImportId]) {
       const universal = p.hub.file.addImport(
@@ -63,6 +67,12 @@ module.exports = function ({ types: t, template }) {
       quasis[0] = Object.assign({}, quasis[0], {
         value: { raw: baseDir, cooked: baseDir }
       })
+      if (quasis[1]) {
+        const newPath = prepareChunkNamePath(quasis[1].value.cooked)
+        quasis[1] = Object.assign({}, quasis[1], {
+          value: { raw: newPath, cooked: newPath }
+        })
+      }
 
       return Object.assign({}, importArgNode, {
         quasis

--- a/index.js
+++ b/index.js
@@ -62,17 +62,13 @@ module.exports = function ({ types: t, template }) {
 
   function createTrimmedChunkName(importArgNode) {
     if (importArgNode.quasis) {
-      const quasis = importArgNode.quasis.slice(0)
+      let quasis = importArgNode.quasis.slice(0)
       const baseDir = trimChunkNameBaseDir(quasis[0].value.cooked)
       quasis[0] = Object.assign({}, quasis[0], {
         value: { raw: baseDir, cooked: baseDir }
       })
-      if (quasis[1]) {
-        const newPath = prepareChunkNamePath(quasis[1].value.cooked)
-        quasis[1] = Object.assign({}, quasis[1], {
-          value: { raw: newPath, cooked: newPath }
-        })
-      }
+
+      quasis = quasis.map((quasi, i) => (i > 0 ? prepareQuasi(quasi) : quasi))
 
       return Object.assign({}, importArgNode, {
         quasis
@@ -81,6 +77,14 @@ module.exports = function ({ types: t, template }) {
 
     const moduleName = trimChunkNameBaseDir(importArgNode.value)
     return t.stringLiteral(moduleName)
+  }
+
+  function prepareQuasi(quasi) {
+    const newPath = prepareChunkNamePath(quasi.value.cooked)
+
+    return Object.assign({}, quasi, {
+      value: { raw: newPath, cooked: newPath }
+    })
   }
 
   function getMagicCommentChunkName(importArgNode) {


### PR DESCRIPTION
Webpack changes slashes for hyphens in nested dynamic imports. This fix solves the problem.

19