### PR TITLE
feat(importCss): use link.onload on supported browsers

### DIFF
--- a/importCss.js
+++ b/importCss.js
@@ -32,7 +32,6 @@ module.exports = function(chunkName, options) {
   var head = document.getElementsByTagName('head')[0]
   var link = document.createElement('link')
 
-  link.href = href
   link.charset = 'utf-8'
   link.type = 'text/css'
   link.rel = 'stylesheet'
@@ -40,6 +39,21 @@ module.exports = function(chunkName, options) {
 
   return new Promise(function(resolve, reject) {
     var timeout
+    var img
+
+    var onload = function() {
+      // Check if we created the img tag.
+      // If we did then the chunk was loaded via img.src
+      // and we need to set the link.href which will then
+      // load the resource from cache
+      if (img) {
+        link.href = href
+        img.onerror = null // avoid mem leaks in IE.
+      }
+      link.onerror = null // avoid mem leaks in IE.
+      clearTimeout(timeout)
+      resolve()
+    }
 
     link.onerror = function() {
       link.onerror = link.onload = null // avoid mem leaks in IE.
@@ -48,22 +62,45 @@ module.exports = function(chunkName, options) {
       reject(new Error(message))
     }
 
-    // link.onload doesn't work well enough, but this will handle it
-    // since images can't load css (this is a popular fix)
-    var img = document.createElement('img')
-    img.onerror = function() {
-      link.onerror = img.onerror = null // avoid mem leaks in IE.
-      clearTimeout(timeout)
-      resolve()
+    if (isOnloadSupported() && 'onload' in link) {
+      link.onload = onload
+      link.href = href
+    } else {
+      // Use img.src as a fallback to loading the css chunk in browsers
+      // which don’t support link.onload
+      // We use the img.onerror handler because an error will always fire
+      // when parsing the response
+      // Then we know the resource has been loaded
+      img = document.createElement('img')
+      img.onerror = onload
+      img.src = href
     }
 
     timeout = setTimeout(link.onerror, link.timeout)
     head.appendChild(link)
-    img.src = href
   })
 }
 
 function getHref(chunkName) {
   if (typeof window === 'undefined' || !window.__CSS_CHUNKS__) return null
   return window.__CSS_CHUNKS__[chunkName]
+}
+
+// Checks whether the browser supports link.onload
+// Reference: https://pie.gd/test/script-link-events/
+function isOnloadSupported() {
+  var userAgent = navigator.userAgent
+  var supportedMajor = 535
+  var supportedMinor = 24
+  var match = userAgent.match(/\ AppleWebKit\/(\d+)\.(\d+)/)
+  if (match) {
+    var major = +match[1]
+    var minor = +match[2]
+    return (
+      (major === supportedMajor && minor >= supportedMinor) ||
+      major > supportedMajor
+    )
+  }
+  // All other browsers support it
+  return true
 }


### PR DESCRIPTION
fix #26

Use `link.onload` on supported browsers but fall back to using the `img.onerror` hack for older browsers.
Currently running on http://ueno.co