### PR TITLE
[EDITED] return promise in case href was used already

### DIFF
--- a/__tests__/__snapshots__/index.js.snap
+++ b/__tests__/__snapshots__/index.js.snap
@@ -6,11 +6,8 @@ async ({ page }) => await import(\`../components/\${page}\`);
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _importCss = _interopRequireDefault(require(\\"babel-plugin-universal-import/importCss\\")).default;
-
-var _universalImport = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\")).default;
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+import _importCss from \\"babel-plugin-universal-import/importCss\\";
+import _universalImport from \\"babel-plugin-universal-import/universalImport\\";
 
 async ({
   page
@@ -26,11 +23,8 @@ import(\\"./Foo\\")
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path = _interopRequireDefault(require(\\"path\\")).default;
-
-var _universalImport = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\")).default;
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+import _path from \\"path\\";
+import _universalImport from \\"babel-plugin-universal-import/universalImport\\";
 
 _universalImport({
   id: \\"./Foo\\",
@@ -48,13 +42,9 @@ import(\\"./Foo\\")
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path = _interopRequireDefault(require(\\"path\\")).default;
-
-var _importCss = _interopRequireDefault(require(\\"babel-plugin-universal-import/importCss\\")).default;
-
-var _universalImport = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\")).default;
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+import _path from \\"path\\";
+import _importCss from \\"babel-plugin-universal-import/importCss\\";
+import _universalImport from \\"babel-plugin-universal-import/universalImport\\";
 
 _universalImport({
   id: \\"./Foo\\",
@@ -77,13 +67,9 @@ import(\`../../base/\${page}\`)
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path = _interopRequireDefault(require(\\"path\\")).default;
-
-var _importCss = _interopRequireDefault(require(\\"babel-plugin-universal-import/importCss\\")).default;
-
-var _universalImport = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\")).default;
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+import _path from \\"path\\";
+import _importCss from \\"babel-plugin-universal-import/importCss\\";
+import _universalImport from \\"babel-plugin-universal-import/universalImport\\";
 
 _universalImport({
   id: \\"../../base/\${page}\\",
@@ -104,13 +90,9 @@ import(\`./\${page}\`)
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path = _interopRequireDefault(require(\\"path\\")).default;
-
-var _importCss = _interopRequireDefault(require(\\"babel-plugin-universal-import/importCss\\")).default;
-
-var _universalImport = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\")).default;
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+import _path from \\"path\\";
+import _importCss from \\"babel-plugin-universal-import/importCss\\";
+import _universalImport from \\"babel-plugin-universal-import/universalImport\\";
 
 _universalImport({
   id: \\"./\${page}\\",
@@ -131,13 +113,9 @@ import(\`./base/\${page}/nested/{$another}folder\`)
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path = _interopRequireDefault(require(\\"path\\")).default;
-
-var _importCss = _interopRequireDefault(require(\\"babel-plugin-universal-import/importCss\\")).default;
-
-var _universalImport = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\")).default;
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+import _path from \\"path\\";
+import _importCss from \\"babel-plugin-universal-import/importCss\\";
+import _universalImport from \\"babel-plugin-universal-import/universalImport\\";
 
 _universalImport({
   id: \\"./base/\${page}/nested/{$another}folder\\",
@@ -158,13 +136,9 @@ import(\`./base/\${page}/nested/folder\`)
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path = _interopRequireDefault(require(\\"path\\")).default;
-
-var _importCss = _interopRequireDefault(require(\\"babel-plugin-universal-import/importCss\\")).default;
-
-var _universalImport = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\")).default;
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+import _path from \\"path\\";
+import _importCss from \\"babel-plugin-universal-import/importCss\\";
+import _universalImport from \\"babel-plugin-universal-import/universalImport\\";
 
 _universalImport({
   id: \\"./base/\${page}/nested/folder\\",
@@ -185,13 +159,9 @@ import(\`./base/\${page}\`)
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path = _interopRequireDefault(require(\\"path\\")).default;
-
-var _importCss = _interopRequireDefault(require(\\"babel-plugin-universal-import/importCss\\")).default;
-
-var _universalImport = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\")).default;
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+import _path from \\"path\\";
+import _importCss from \\"babel-plugin-universal-import/importCss\\";
+import _universalImport from \\"babel-plugin-universal-import/universalImport\\";
 
 _universalImport({
   id: \\"./base/\${page}\\",
@@ -212,13 +182,9 @@ import(\`../../base\`)
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path = _interopRequireDefault(require(\\"path\\")).default;
-
-var _importCss = _interopRequireDefault(require(\\"babel-plugin-universal-import/importCss\\")).default;
-
-var _universalImport = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\")).default;
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+import _path from \\"path\\";
+import _importCss from \\"babel-plugin-universal-import/importCss\\";
+import _universalImport from \\"babel-plugin-universal-import/universalImport\\";
 
 _universalImport({
   id: \\"../../base\\",
@@ -239,13 +205,9 @@ import(\`./base\`)
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path = _interopRequireDefault(require(\\"path\\")).default;
-
-var _importCss = _interopRequireDefault(require(\\"babel-plugin-universal-import/importCss\\")).default;
-
-var _universalImport = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\")).default;
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+import _path from \\"path\\";
+import _importCss from \\"babel-plugin-universal-import/importCss\\";
+import _universalImport from \\"babel-plugin-universal-import/universalImport\\";
 
 _universalImport({
   id: \\"./base\\",
@@ -266,13 +228,9 @@ import(\\"./Foo.js\\")
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path = _interopRequireDefault(require(\\"path\\")).default;
-
-var _importCss = _interopRequireDefault(require(\\"babel-plugin-universal-import/importCss\\")).default;
-
-var _universalImport = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\")).default;
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+import _path from \\"path\\";
+import _importCss from \\"babel-plugin-universal-import/importCss\\";
+import _universalImport from \\"babel-plugin-universal-import/universalImport\\";
 
 _universalImport({
   id: \\"./Foo.js\\",
@@ -293,13 +251,9 @@ import(\\"../../Foo\\")
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path = _interopRequireDefault(require(\\"path\\")).default;
-
-var _importCss = _interopRequireDefault(require(\\"babel-plugin-universal-import/importCss\\")).default;
-
-var _universalImport = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\")).default;
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+import _path from \\"path\\";
+import _importCss from \\"babel-plugin-universal-import/importCss\\";
+import _universalImport from \\"babel-plugin-universal-import/universalImport\\";
 
 _universalImport({
   id: \\"../../Foo\\",
@@ -320,13 +274,9 @@ import(\\"./Foo\\")
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path = _interopRequireDefault(require(\\"path\\")).default;
-
-var _importCss = _interopRequireDefault(require(\\"babel-plugin-universal-import/importCss\\")).default;
-
-var _universalImport = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\")).default;
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+import _path from \\"path\\";
+import _importCss from \\"babel-plugin-universal-import/importCss\\";
+import _universalImport from \\"babel-plugin-universal-import/universalImport\\";
 
 _universalImport({
   id: \\"./Foo\\",

--- a/importCss.js
+++ b/importCss.js
@@ -24,10 +24,9 @@ module.exports = function(chunkName, options) {
     return
   }
 
-  if (ADDED[href] === true) {
-    return Promise.resolve()
+  if (ADDED[href]) {
+    return ADDED[href]
   }
-  ADDED[href] = true
 
   var head = document.getElementsByTagName('head')[0]
   var link = document.createElement('link')
@@ -37,9 +36,8 @@ module.exports = function(chunkName, options) {
   link.rel = 'stylesheet'
   link.timeout = 30000
 
-  return new Promise(function(resolve, reject) {
-    var timeout
-    var img
+  var promise = new Promise(function(resolve, reject) {
+    var timeout, img
 
     var onload = function() {
       // Check if we created the img tag.
@@ -58,8 +56,7 @@ module.exports = function(chunkName, options) {
     link.onerror = function() {
       link.onerror = link.onload = null // avoid mem leaks in IE.
       clearTimeout(timeout)
-      var message = 'could not load css chunk: ' + chunkName
-      reject(new Error(message))
+      reject(new Error('could not load css chunk: ' + chunkName))
     }
 
     if (isOnloadSupported() && 'onload' in link) {
@@ -79,6 +76,10 @@ module.exports = function(chunkName, options) {
     timeout = setTimeout(link.onerror, link.timeout)
     head.appendChild(link)
   })
+
+  ADDED[href] = promise
+
+  return promise
 }
 
 function getHref(chunkName) {


### PR DESCRIPTION
that would help in case you have multiple lazy chunks combined in a one file.

For example, let's say you have 2 lazy components and you'd like to load them together in terms of network requests. For that reason you'll specify the same webpackChunkName for both, like shown below:

```js

// SomeComponentLazy.js
export default universal(universalImport({
    chunkName: () => 'file-with-chunks',
    path: () => path.join(__dirname, './SomeComponent'),
    resolve: () => require.resolveWeak('./SomeComponent'),
    load: () => Promise.all([
        import(/* webpackChunkName: "file-with-chunks" */'./SomeComponent'),
        importCss('file-with-chunks'),
    ]).then(proms => proms[0]),
}));


// AnotherComponentLazy.js
export default universal(universalImport({
    chunkName: () => 'file-with-chunks',
    path: () => path.join(__dirname, './AnotherComponentLazy'),
    resolve: () => require.resolveWeak('./AnotherComponentLazy'),
    load: () => Promise.all([
        import(/* webpackChunkName: "file-with-chunks" */'./AnotherComponentLazy'),
        importCss('file-with-chunks'),
    ]).then(proms => proms[0]),
}));

```

But, since you have the same name href here for both components that would mean that the first component would be loaded properly, because promise would be resolved only when css is loaded but the second component could be rendered on the page without css because href is the same and promise would be resolved immediately.

And if we return the same promise back then both components would be rendered only after css is completely fetched.

Thanks.
