### PR TITLE
fix(importCss.js): To return promise in case href was used already

### DIFF
--- a/importCss.js
+++ b/importCss.js
@@ -24,10 +24,9 @@ module.exports = function(chunkName, options) {
     return
   }
 
-  if (ADDED[href] === true) {
-    return Promise.resolve()
+  if (ADDED[href]) {
+    return ADDED[href]
   }
-  ADDED[href] = true
 
   var head = document.getElementsByTagName('head')[0]
   var link = document.createElement('link')
@@ -37,9 +36,8 @@ module.exports = function(chunkName, options) {
   link.rel = 'stylesheet'
   link.timeout = 30000
 
-  return new Promise(function(resolve, reject) {
-    var timeout
-    var img
+  var promise = new Promise(function(resolve, reject) {
+    var timeout, img
 
     var onload = function() {
       // Check if we created the img tag.
@@ -58,8 +56,7 @@ module.exports = function(chunkName, options) {
     link.onerror = function() {
       link.onerror = link.onload = null // avoid mem leaks in IE.
       clearTimeout(timeout)
-      var message = 'could not load css chunk: ' + chunkName
-      reject(new Error(message))
+      reject(new Error('could not load css chunk: ' + chunkName))
     }
 
     if (isOnloadSupported() && 'onload' in link) {
@@ -79,6 +76,10 @@ module.exports = function(chunkName, options) {
     timeout = setTimeout(link.onerror, link.timeout)
     head.appendChild(link)
   })
+
+  ADDED[href] = promise
+
+  return promise
 }
 
 function getHref(chunkName) {


### PR DESCRIPTION
That would help in case you have multiple lazy chunks combined in a one file. 

For example, let's say you have 2 lazy components and you'd like to load them together in terms of network requests. For that reason you'll specify the same webpackChunkName for both, like shown below:

```js

// SomeComponentLazy.js
export default universal(universalImport({
    chunkName: () => 'file-with-chunks',
    path: () => path.join(__dirname, './SomeComponent'),
    resolve: () => require.resolveWeak('./SomeComponent'),
    load: () => Promise.all([
        import(/* webpackChunkName: "file-with-chunks" */'./SomeComponent'),
        importCss('file-with-chunks'),
    ]).then(proms => proms[0]),
}));


// AnotherComponentLazy.js
export default universal(universalImport({
    chunkName: () => 'file-with-chunks',
    path: () => path.join(__dirname, './AnotherComponentLazy'),
    resolve: () => require.resolveWeak('./AnotherComponentLazy'),
    load: () => Promise.all([
        import(/* webpackChunkName: "file-with-chunks" */'./AnotherComponentLazy'),
        importCss('file-with-chunks'),
    ]).then(proms => proms[0]),
}));

```


But, since you have the same name href here for both components that would mean that the first component would be loaded properly, because promise would be resolved only when css is loaded but the second component could be rendered on the page without css because href is the same and promise would be resolved immediately. 

And if we return the same promise back then both components would be rendered only after css is completely fetched.

Thanks.