### PR TITLE
fix(loadOption): Wrong chunkName generated in nested imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist
 coverage
 node_modules
 *.log
+.idea

--- a/__tests__/__snapshots__/index.js.snap
+++ b/__tests__/__snapshots__/index.js.snap
@@ -224,7 +224,7 @@ _universalImport({
   id: \\"./Foo\\",
   file: \\"currentFile.js\\",
   load: () => Promise.all([import(
-  /* webpackChunkName: 'Bar' */
+  /* webpackChunkName: 'Foo' */
   \\"./Foo\\"), _importCss(\\"Bar\\", {})]).then(proms => proms[0]),
   path: () => _path.join(__dirname, \\"./Foo\\"),
   resolve: () => require.resolveWeak(\\"./Foo\\"),
@@ -311,6 +311,37 @@ _universalImport({
   resolve: () => require.resolveWeak(\\"./Foo.js\\"),
   chunkName: () => \\"Foo\\"
 });
+"
+`;
+
+exports[`static import (with relative paths + nested folder) 1`] = `
+"
+const obj = {component:()=>import(\`../components/nestedComponent\`)}; ()=> obj.component()
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+var _path = _interopRequireDefault(require(\\"path\\")).default;
+
+var _importCss = _interopRequireDefault(require(\\"babel-plugin-universal-import/importCss\\")).default;
+
+var _universalImport = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\")).default;
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+const obj = {
+  component: () => _universalImport({
+    id: \\"../components/nestedComponent\\",
+    file: \\"currentFile.js\\",
+    load: () => Promise.all([import(
+    /* webpackChunkName: 'components-nestedComponent' */
+    \`../components/nestedComponent\`), _importCss(\`components/nestedComponent\`, {})]).then(proms => proms[0]),
+    path: () => _path.join(__dirname, \`../components/nestedComponent\`),
+    resolve: () => require.resolveWeak(\`../components/nestedComponent\`),
+    chunkName: () => \`components/nestedComponent\`
+  })
+};
+
+() => obj.component();
 "
 `;
 

--- a/__tests__/__snapshots__/index.js.snap
+++ b/__tests__/__snapshots__/index.js.snap
@@ -224,8 +224,8 @@ _universalImport({
   id: \\"./Foo\\",
   file: \\"currentFile.js\\",
   load: () => Promise.all([import(
-  /* webpackChunkName: 'Foo' */
-  \\"./Foo\\"), _importCss(\\"Bar\\", {})]).then(proms => proms[0]),
+  /* webpackChunkName: 'Bar' */
+  \\"./Foo\\"), _importCss(\\"Foo\\", {})]).then(proms => proms[0]),
   path: () => _path.join(__dirname, \\"./Foo\\"),
   resolve: () => require.resolveWeak(\\"./Foo\\"),
   chunkName: () => \\"Bar\\"
@@ -334,10 +334,10 @@ const obj = {
     file: \\"currentFile.js\\",
     load: () => Promise.all([import(
     /* webpackChunkName: 'components-nestedComponent' */
-    \`../components/nestedComponent\`), _importCss(\`components/nestedComponent\`, {})]).then(proms => proms[0]),
+    \`../components/nestedComponent\`), _importCss(\\"components/nestedComponent\\", {})]).then(proms => proms[0]),
     path: () => _path.join(__dirname, \`../components/nestedComponent\`),
     resolve: () => require.resolveWeak(\`../components/nestedComponent\`),
-    chunkName: () => \`components/nestedComponent\`
+    chunkName: () => \\"components-nestedComponent\\"
   })
 };
 

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -25,6 +25,8 @@ pluginTester({
     'static import (with file extension)': 'import("./Foo.js")',
     'static import (string template)': 'import(`./base`)',
     'static import (string template + relative paths)': 'import(`../../base`)',
+    'static import (with relative paths + nested folder)':
+      'const obj = {component:()=>import(`../components/nestedComponent`)}; ()=> obj.component()',
     'dynamic import (string template)': 'import(`./base/${page}`)',
     'dynamic import (string template with nested folder)':
       'import(`./base/${page}/nested/folder`)',


### PR DESCRIPTION
fix(loadOption): Wrong chunkName generated in nested imports
So if you import('../Something/Somethingelse') the chunkName is Something/Somethingelse. However if
i look in webpack clientStats - its Something-Somethingelse. I replace `/` with - as long as `[request]`
isn't present in the string and `/` is.

To do this, i actually just hooked into my previous features pull request. Essentially nested imports *without* a custom magic comment are put through the `checkForNestedChunkName` if its indeed a nested chunkName, i pretty much make it the `existingMagicComment` Which literally does everything we need without adding much weight or complexity to the project 

*Im not sure of the available es6 support, have you considered creating an es6 class? there would be alot less things being passed all over the show and instance variables could be used and set in the constructor. It might simplify things even :P* let me know your thoughts - i dont mind submitting a pr

fix #39


fix(loadOption): Magic Comment importCss was renamed

After fixing the nested import bug, i refactored some logic around how the chunkname finds which way it needs to be processed. I noticed that my test failed on my previous work.

I took a closer look and it pretty much took the magic comment chunk name and not the actual one

Im currently running this branch across multiple large vertices without a hitch :) 