### PR TITLE
fix(loadOption): Ensure the argument passed to importCss matches the …

### DIFF
--- a/__tests__/__snapshots__/index.js.snap
+++ b/__tests__/__snapshots__/index.js.snap
@@ -225,7 +225,7 @@ _universalImport({
   file: \\"currentFile.js\\",
   load: () => Promise.all([import(
   /* webpackChunkName: 'Bar' */
-  \\"./Foo\\"), _importCss(\\"Foo\\", {})]).then(proms => proms[0]),
+  \\"./Foo\\"), _importCss(\\"Bar\\", {})]).then(proms => proms[0]),
   path: () => _path.join(__dirname, \\"./Foo\\"),
   resolve: () => require.resolveWeak(\\"./Foo\\"),
   chunkName: () => \\"Bar\\"
@@ -253,7 +253,7 @@ const obj = {
     file: \\"currentFile.js\\",
     load: () => Promise.all([import(
     /* webpackChunkName: 'components-nestedComponent' */
-    \`../components/nestedComponent\`), _importCss(\\"components/nestedComponent\\", {})]).then(proms => proms[0]),
+    \`../components/nestedComponent\`), _importCss(\\"components-nestedComponent\\", {})]).then(proms => proms[0]),
     path: () => _path.join(__dirname, \`../components/nestedComponent\`),
     resolve: () => require.resolveWeak(\`../components/nestedComponent\`),
     chunkName: () => \\"components-nestedComponent\\"
@@ -283,7 +283,7 @@ _universalImport({
   file: \\"currentFile.js\\",
   load: () => Promise.all([import(
   /* webpackChunkName: 'components-nestedComponent' */
-  \`../components/nestedComponent\`), _importCss(\\"components/nestedComponent\\", {})]).then(proms => proms[0]),
+  \`../components/nestedComponent\`), _importCss(\\"components-nestedComponent\\", {})]).then(proms => proms[0]),
   path: () => _path.join(__dirname, \`../components/nestedComponent\`),
   resolve: () => require.resolveWeak(\`../components/nestedComponent\`),
   chunkName: () => \\"components-nestedComponent\\"

--- a/index.js
+++ b/index.js
@@ -149,7 +149,7 @@ function loadOption(t, loadTemplate, p, importArgNode, cssOptions) {
   const existingChunkName = t.existingChunkName
   const chunkName = existingChunkName || generatedChunkName
   const trimmedChunkName = existingChunkName
-    ? t.stringLiteral(generatedChunkName)
+    ? t.stringLiteral(existingChunkName)
     : createTrimmedChunkName(t, importArgNode)
 
   delete argPath.node.leadingComments


### PR DESCRIPTION
…chunkName, with dashed logic applied.

This fixes the problem I ran into where my CSS was  not loading due to mismatch.

The existing code is difficult to follow, but I believe my fix is correct.

This one liner reverts the logic to an earlier point in history.
https://github.com/faceyspacey/babel-plugin-universal-import/blob/16396dc2969b0258a68765d96236bf5b8e29acd3/index.js#L152

cc: @zackljackson 