### PR TITLE
Make import promise load the module before .then() or .catch() is called on it

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["@babel/preset-react"],
+  "plugins": ["@babel/plugin-transform-modules-commonjs"]
+}

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Taking from the [test snapshots](./__tests__/__snapshots__/index.js.snap), it do
 
 ```js
 import universal from 'react-universal-component'
-const UniversalComponent = universal(import('./Foo.js'))
+const UniversalComponent = universal(() => import('./Foo.js'))
 
 <UniversalComponent />
 
@@ -66,7 +66,7 @@ import universal from 'react-universal-component'
 import universalImport from 'babel-plugin-universal-import/universalImport.js'
 import path from 'path'
 
-const UniversalComponent = universal(universalImport({
+const UniversalComponent = universal(() => universalImport({
   chunkName: () => 'Foo',
   path: () => path.join(__dirname, './Foo.js'),
   resolve: () => require.resolveWeak('./Foo.js'),
@@ -112,8 +112,6 @@ Otherwise, what it's doing is providing all the different types of requires/path
 The targeted **use-case** for all this is dynamic imports where you can pass a `page` prop to the resulting component, thereby allowing you to create one `<UniversalComponent page={page} />` for a large number of your components. This is a major upgrade to the previous way of having to make a hash of a million async components in a wrapping component. You no longer have to think about *Universal Components* as anything different than your other components that use simple HoCs.
 
 
-And maybe even *cooler* to some: you don't have to do `universal(() => import())`. I.e. you don't have to wrap it in a function any longer when using `react-universal-component`, similar to `dynamic(import())` in Next.js...*unless of course you're making use of the extremely useful `props` argument.*
-
 ## Typescript and non-Babel environments
 
 If you can't use babel, you can either copy what this plugin does above, or you can do a shorter version where you just put the important configuration key/vals on the 2nd options argument to `universal`:
@@ -155,8 +153,6 @@ Checkout the rest of the packages in the *"Universal"* family:
 
 ## Caveat
 - For chunks to be properly created--and since their names are automatically generated for you--you can't have different chunks with the same name, say `index`. So instead of ```import(`./index`)```, make your imports like this: ```import(`../ComponentFolderA`)``` and ```import(`../ComponentFolderB`)```. Notice you're going back one directory--this allows the chunk name to be generated uniquely even though the entry point file is `index.js` for both components. In addition, if in multiple places you import the same module, make sure they both start with the same base directory name. **Again, using `..` is your friend. Initial dots and slashes will be stripped from the resulting chunk name.**
-
-- To the discerning eye, you may be wondering if the return of `import()` is still *thenable*?? It is! However, if you don't call `.then` on it, somewhere (perhaps in the components like *react-universal-component* that you pass it to), then it won't perform the import. Since most of us are using modules, which we need to do something with in the `then` callback, that's not a problem. But if you happen to be importing a module that does its own setup, such as attaches something to the `window` object, well then you just need to call `.then()` to trigger it. That's a rare case these days, which is why we decided to go with the simplicity seen here. And yes, async await works too.
 
 ## Contributing
 

--- a/__tests__/universalImport.js
+++ b/__tests__/universalImport.js
@@ -1,0 +1,54 @@
+import universalImport from '../universalImport'
+
+describe('universalImport function functions as expected', () => {
+  it('executes the promise', () => {
+    const load = jest.fn()
+    const config = {
+      load: () => new Promise(load)
+    }
+    const result = universalImport(config)
+    expect(load).toHaveBeenCalled()
+  })
+
+  it('executes chained promise', () => {
+    let resolvePromise
+    const config = {
+      load: () =>
+        new Promise(resolve => {
+          resolvePromise = resolve
+        })
+    }
+    const result = universalImport(config)
+    const chainedFunction = jest.fn()
+    const catchFunction = jest.fn()
+    result.then(chainedFunction)
+    result.catch(catchFunction)
+    expect(chainedFunction).not.toHaveBeenCalled()
+    resolvePromise()
+    return Promise.resolve().then(() => {
+      expect(chainedFunction).toHaveBeenCalled()
+      expect(catchFunction).not.toHaveBeenCalled()
+    })
+  })
+
+  it('executes chained catch', () => {
+    let rejectPromise
+    const config = {
+      load: () =>
+        new Promise((_, reject) => {
+          rejectPromise = reject
+        })
+    }
+    const result = universalImport(config)
+    const chainedFunction = jest.fn()
+    const catchFunction = jest.fn()
+    result.then(chainedFunction)
+    result.catch(catchFunction)
+    expect(chainedFunction).not.toHaveBeenCalled()
+    rejectPromise()
+    return Promise.resolve().then(() => {
+      expect(chainedFunction).not.toHaveBeenCalled()
+      expect(catchFunction).toHaveBeenCalled()
+    })
+  })
+})

--- a/universalImport.js
+++ b/universalImport.js
@@ -3,18 +3,27 @@
 module.exports = function(config, makeThennable) {
   if (makeThennable === false) return config
 
-  var load = config.load()
+  var load = config.load
+  !(isServer() || config.testServer) && load && load()
   config.then = function(cb) {
-    return load.then(function(res) {
+    return load().then(function(res) {
       return cb && cb(res)
     })
   }
   config.catch = function(cb) {
-    return load.catch(function(e) {
+    return load().catch(function(e) {
       return cb && cb(e)
     })
   }
   return config
+}
+
+function isServer() {
+  return !(
+    typeof window !== 'undefined' &&
+    window.document &&
+    window.document.createElement
+  )
 }
 
 var isSet = false

--- a/universalImport.js
+++ b/universalImport.js
@@ -3,14 +3,14 @@
 module.exports = function(config, makeThennable) {
   if (makeThennable === false) return config
 
-  var load = config.load
+  var load = config.load()
   config.then = function(cb) {
-    return load().then(function(res) {
+    return load.then(function(res) {
       return cb && cb(res)
     })
   }
   config.catch = function(cb) {
-    return load().catch(function(e) {
+    return load.catch(function(e) {
       return cb && cb(e)
     })
   }


### PR DESCRIPTION
#### Problem ####

See https://github.com/faceyspacey/babel-plugin-universal-import/issues/50

There is a discrepancy between the way that `import()` behaves on the client side when using webpack with and without this plugin. When using webpack, calling `import('./someModule')` causes `someModule.js` to be executed. When using the plugin, it does not - instead the module is only executed when `.then()` or `.catch()` is called on the promise returned from `import()`.

I think this is an important issue because it can cause serious bugs in apps that rely on webpack's standard behaviour. If a module is asynchronously imported and its exports are not needed, then there is no obvious reason to call `.then()` or `.catch()` on the import promise - and its unexpected/non-idiomatic for `.then()` or `.catch()` to have side effects. In this case, installing the plugin will silently break the loading of the module. This kind of problem is unexpected and difficult to test for.


#### Solution ####

This change brings the behaviour of this plugin in line with webpack's built in handling of `import()`. Users migrating from webpack's built in handling of `import()` no longer have to change any code or experience any bugs when installing this plugin.


#### Breaking change ####
`import()` now loads and executes the module immediately instead of waiting until `.then()` or `.catch()` is called on it. To continue to take advantage of async chunk loading via `react-universal-component` it is necessary to change `universal(import('./component'))` to `universal(() => import('./component'))`, otherwise `component.js` will be loaded and executed even if it is not mounted.


#### Docs ####
 * README updated to always wrap `import()` in a function
 * accompanying PR for `react-universal-component` to update the docs to always wrap `import()` in a function: https://github.com/faceyspacey/react-universal-component/pull/125


#### Tests ####
 * Existing tests pass
 * New tests added to test the behaviour of `universalImport.js`
 * Tests in `react-universal-component` pass when using this version of the plugin
 * `redux-first-router-demo` works when using this version of the plugin and a version of `react-universal-component` which depends on it, including deferring the loading of chunks for components that are not in the initial render
 * calling `import('someModule')` on its own results in `someModule.js` being executed