### PR TITLE
fix(babel-plugin-universal-import): Prevent exposing filename & move to optional settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,20 @@ If your compiling the server with Babel, set the following option so `import()` 
 }
 ```
 
+## Include additional debugging info
+To prevent leaking of information, file names are not included in the final output. However, for debugging purposes, you may set the `includeFileName` flag option to true.  This will include the path to the source file from which the import() is happening to be exposed.
+
+```js
+{
+  "plugins": [
+    ["universal-import", {
+      "includeFileName": true
+    }]
+  ]
+}
+```
+
+
 ## Next Steps
 
 Checkout the rest of the packages in the *"Universal"* family:

--- a/__tests__/__snapshots__/index.js.snap
+++ b/__tests__/__snapshots__/index.js.snap
@@ -32,7 +32,6 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 (0, _universalImport2.default)({
   id: \\"./Foo\\",
-  file: \\"/dev/null\\",
   path: () => _path2.default.join(__dirname, \\"./Foo\\"),
   resolve: () => require.resolveWeak(\\"./Foo\\"),
   chunkName: () => \\"Foo\\"
@@ -54,7 +53,6 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 (0, _universalImport2.default)({
   id: \\"./Foo\\",
-  file: \\"/dev/null\\",
   load: () => Promise.all([import(
   /* webpackChunkName: 'Foo' */
   \\"./Foo\\")]).then(proms => proms[0]),
@@ -79,7 +77,6 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 (0, _universalImport2.default)({
   id: \\"../../base/\${page}\\",
-  file: \\"/dev/null\\",
   load: () => Promise.all([import(
   /* webpackChunkName: 'base/[request]' */
   \`../../base/\${page}\`)]).then(proms => proms[0]),
@@ -104,7 +101,6 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 (0, _universalImport2.default)({
   id: \\"./\${page}\\",
-  file: \\"/dev/null\\",
   load: () => Promise.all([import(
   /* webpackChunkName: '[request]' */
   \`./\${page}\`)]).then(proms => proms[0]),
@@ -129,7 +125,6 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 (0, _universalImport2.default)({
   id: \\"./base/\${page}/nested/{$another}folder\\",
-  file: \\"/dev/null\\",
   load: () => Promise.all([import(
   /* webpackChunkName: 'base/[request]' */
   \`./base/\${page}/nested/{$another}folder\`)]).then(proms => proms[0]),
@@ -154,7 +149,6 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 (0, _universalImport2.default)({
   id: \\"./base/\${page}/nested/folder\\",
-  file: \\"/dev/null\\",
   load: () => Promise.all([import(
   /* webpackChunkName: 'base/[request]' */
   \`./base/\${page}/nested/folder\`)]).then(proms => proms[0]),
@@ -179,7 +173,6 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 (0, _universalImport2.default)({
   id: \\"./base/\${page}\\",
-  file: \\"/dev/null\\",
   load: () => Promise.all([import(
   /* webpackChunkName: 'base/[request]' */
   \`./base/\${page}\`)]).then(proms => proms[0]),
@@ -204,7 +197,6 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 (0, _universalImport2.default)({
   id: \\"./Foo\\",
-  file: \\"/dev/null\\",
   load: () => Promise.all([import(
   /* webpackChunkName: 'Bar' */
   \\"./Foo\\")]).then(proms => proms[0]),
@@ -229,7 +221,6 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 (0, _universalImport4.default)({
   id: \\"one\\",
-  file: \\"/dev/null\\",
   load: () => Promise.all([import(
   /* webpackChunkName: 'one' */
   \\"one\\")]).then(proms => proms[0]),
@@ -239,7 +230,6 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 });
 (0, _universalImport4.default)({
   id: \\"two\\",
-  file: \\"/dev/null\\",
   load: () => Promise.all([import(
   /* webpackChunkName: 'two' */
   \\"two\\")]).then(proms => proms[0]),
@@ -249,7 +239,6 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 });
 (0, _universalImport4.default)({
   id: \\"three\\",
-  file: \\"/dev/null\\",
   load: () => Promise.all([import(
   /* webpackChunkName: 'three' */
   \\"three\\")]).then(proms => proms[0]),
@@ -275,7 +264,6 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 const obj = {
   component: () => (0, _universalImport2.default)({
     id: \\"../components/nestedComponent\\",
-    file: \\"/dev/null\\",
     load: () => Promise.all([import(
     /* webpackChunkName: 'components-nestedComponent' */
     \`../components/nestedComponent\`)]).then(proms => proms[0]),
@@ -303,7 +291,6 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 (0, _universalImport2.default)({
   id: \\"../components/nestedComponent\\",
-  file: \\"/dev/null\\",
   load: () => Promise.all([import(
   /* webpackChunkName: 'components-nestedComponent' */
   \`../components/nestedComponent\`)]).then(proms => proms[0]),
@@ -328,7 +315,6 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 (0, _universalImport2.default)({
   id: \\"../../base\\",
-  file: \\"/dev/null\\",
   load: () => Promise.all([import(
   /* webpackChunkName: 'base' */
   \`../../base\`)]).then(proms => proms[0]),
@@ -353,7 +339,6 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 (0, _universalImport2.default)({
   id: \\"./base\\",
-  file: \\"/dev/null\\",
   load: () => Promise.all([import(
   /* webpackChunkName: 'base' */
   \`./base\`)]).then(proms => proms[0]),
@@ -378,7 +363,6 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 (0, _universalImport2.default)({
   id: \\"./Foo.js\\",
-  file: \\"/dev/null\\",
   load: () => Promise.all([import(
   /* webpackChunkName: 'Foo' */
   \\"./Foo.js\\")]).then(proms => proms[0]),
@@ -403,7 +387,6 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 (0, _universalImport2.default)({
   id: \\"../../Foo\\",
-  file: \\"/dev/null\\",
   load: () => Promise.all([import(
   /* webpackChunkName: 'Foo' */
   \\"../../Foo\\")]).then(proms => proms[0]),
@@ -428,7 +411,6 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 (0, _universalImport2.default)({
   id: \\"./Foo\\",
-  file: \\"/dev/null\\",
   load: () => Promise.all([import(
   /* webpackChunkName: 'Foo' */
   \\"./Foo\\")]).then(proms => proms[0]),

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -4,9 +4,12 @@ const pluginTester = require('babel-plugin-tester')
 const createBabylonOptions = require('babylon-options')
 const plugin = require('../index')
 const babel = require('@babel/core')
+const process = require('process')
+
+const isWindows = process.platform === 'win32'
 
 const babelOptions = {
-  filename: '/dev/null',
+  filename: isWindows ? 'C:/user/folder' : '/dev/null',
   parserOpts: createBabylonOptions({
     plugins: ['dynamicImport']
   }),

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -4,12 +4,8 @@ const pluginTester = require('babel-plugin-tester')
 const createBabylonOptions = require('babylon-options')
 const plugin = require('../index')
 const babel = require('@babel/core')
-const process = require('process')
-
-const isWindows = process.platform === 'win32'
 
 const babelOptions = {
-  filename: isWindows ? 'C:/user/folder' : '/dev/null',
   parserOpts: createBabylonOptions({
     plugins: ['dynamicImport']
   }),

--- a/index.js
+++ b/index.js
@@ -114,7 +114,6 @@ function fileOption(t, p) {
     t.stringLiteral(
       path.relative(__dirname, p.hub.file.opts.filename || '') || ''
     )
-    // t.stringLiteral(p.hub.file.opts.filename)
   )
 }
 

--- a/index.js
+++ b/index.js
@@ -205,22 +205,23 @@ module.exports = function universalImportPlugin({ types: t, template }) {
           return
         }
 
-        const opts = this.opts.babelServer
+        const opts = (this.opts.babelServer
           ? [
             idOption(t, importArgNode),
-            fileOption(t, p),
+            this.opts.includeFileName ? fileOption(t, p) : undefined,
             pathOption(t, pathTemplate, p, importArgNode),
             resolveOption(t, resolveTemplate, importArgNode),
             chunkNameOption(t, chunkNameTemplate, importArgNode)
           ]
           : [
             idOption(t, importArgNode),
-            fileOption(t, p),
+            this.opts.includeFileName ? fileOption(t, p) : undefined,
             loadOption(t, loadTemplate, p, importArgNode), // only when not on a babel-server
             pathOption(t, pathTemplate, p, importArgNode),
             resolveOption(t, resolveTemplate, importArgNode),
             chunkNameOption(t, chunkNameTemplate, importArgNode)
           ]
+        ).filter(p => p)
 
         const options = t.objectExpression(opts)
 

--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@
 
 const { addDefault } = require('@babel/helper-module-imports')
 
+const path = require('path')
+
 const visited = Symbol('visited')
 
 const IMPORT_UNIVERSAL_DEFAULT = {
@@ -109,7 +111,10 @@ function idOption(t, importArgNode) {
 function fileOption(t, p) {
   return t.objectProperty(
     t.identifier('file'),
-    t.stringLiteral(p.hub.file.opts.filename)
+    t.stringLiteral(
+      path.relative(__dirname, p.hub.file.opts.filename || '') || ''
+    )
+    // t.stringLiteral(p.hub.file.opts.filename)
   )
 }
 
@@ -221,7 +226,7 @@ module.exports = function universalImportPlugin({ types: t, template }) {
             resolveOption(t, resolveTemplate, importArgNode),
             chunkNameOption(t, chunkNameTemplate, importArgNode)
           ]
-        ).filter(p => p)
+        ).filter(Boolean)
 
         const options = t.objectExpression(opts)
 


### PR DESCRIPTION
By default, file was always a property generated and pointed to the source file including full path
to the file. This is an unnecessary exposure of information. Moved to a flag setting. Also tests
were depending on this and were specific to *nix folder/file resolution, making updates to this
plugin from a different system impossible.

snapshots also updated