### PR TITLE
Fix webpack critical dependency warning

### DIFF
--- a/universalImport.js
+++ b/universalImport.js
@@ -29,8 +29,7 @@ function setHasPlugin() {
       var weakId = require.resolveWeak('react-universal-component')
       universal = __webpack_require__(weakId)
     } else {
-      var pkg = 'react-universal-component'
-      universal = module.require(pkg)
+      universal = module.require('react-universal-component')
     }
 
     if (universal) {


### PR DESCRIPTION
By not assigning a constant string that is used as an import path to a variable, we can make it absolutely crystal clear to webpack that the thing being imported is not dynamic.

Solves errors like

```
WARNING in ./node_modules/babel-plugin-universal-import/universalImport.js 33:18-37
    Critical dependency: the request of a dependency is an expression
```