### PR TITLE
Feature: Adds support for well known webpack magic comment strings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,6 +37,7 @@ module.exports = {
     alert: true
   },
   rules: {
+    quotes: ['error', 'single', { allowTemplateLiterals: true }],
     'import/extensions': [
       'error',
       'always',

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ const UniversalComponent = universal(props => universalImport({
 ```
 > NOTE: if you aren't using `react-universal-component` and you just want to serve CSS chunks from [extract-css-chunks-webpack-plugin](https://github.com/faceyspacey/extract-css-chunks-webpack-plugin), its not a problem! extract-css-chunks is completely standalone and fully HMR
 
-It names all your chunks using *magic comments* 🔮 behind the scenes and is derived from the imported file. This works with both static and dynamic import paths, as you can see above.
+It names all your chunks using *magic comments* (see webpack documentation on [magic comments](https://webpack.js.org/api/module-methods/#import-)) 🔮 behind the scenes and is derived from the imported file. This works with both static and dynamic import paths, as you can see above.
 
 Otherwise, what it's doing is providing all the different types of requires/paths/imports/etc needed by tools like [react-universal-component](https://github.com/faceyspacey/react-universal-component) to universally render your component.
 
@@ -158,6 +158,28 @@ To prevent leaking of information, file names are not included in the final outp
   ]
 }
 ```
+
+## Advanced magic comments
+This plugin supports currying of the following magic comments defiend by Webpack to the transpiled output:
+
+- `webpackMode`
+- `webpackInclude`
+- `webpackExclude`
+- `webpackIgnore`
+- `webpackPreload`
+- `webpackPrefetch`
+
+In order to pass that on to the output, you must provide each magic comment in it's own comment block, e.g.
+
+```javascript
+import(
+  /* webpackMode: "lazy" */
+  /* webpackChunkName: "Foo" */
+  "./Foo"
+)
+```
+
+Order in which you specify them will not matter, and invalid leading comments will be stripped out. The logic for naming your webpack chunks remains the same if you specify any of these advanced options.  Please refer to the [webpack documentation](https://webpack.js.org/api/module-methods/#import-) for valid values and configurations of each of these settings.
 
 
 ## Next Steps

--- a/__tests__/__snapshots__/index.test.js.snap
+++ b/__tests__/__snapshots__/index.test.js.snap
@@ -183,6 +183,223 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 "
 `;
 
+exports[`existing chunkName + strips out unknown things 1`] = `
+"
+import(
+  /* webpackFakeProperty1: \\"Lazy\\" */
+  /* webpackChunkName: 'Bar'*/
+  /* webpackFakeProperty3123: /foobar/ */
+  \\"./Foo\\")
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+var _path2 = _interopRequireDefault(require(\\"path\\"));
+
+var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+(0, _universalImport2.default)({
+  id: \\"./Foo\\",
+  load: () => Promise.all([import(
+  /* webpackChunkName: 'Foo' */
+  \\"./Foo\\")]).then(proms => proms[0]),
+  path: () => _path2.default.join(__dirname, \\"./Foo\\"),
+  resolve: () => require.resolveWeak(\\"./Foo\\"),
+  chunkName: () => \\"Foo\\"
+});
+"
+`;
+
+exports[`existing chunkName + webpackPrefetch 1`] = `
+"
+import(
+  /* webpackChunkName: 'Bar'*/
+  /* webpackPrefetch: true */
+  \\"./Foo\\")
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+var _path2 = _interopRequireDefault(require(\\"path\\"));
+
+var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+(0, _universalImport2.default)({
+  id: \\"./Foo\\",
+  load: () => Promise.all([import(
+  /* webpackPrefetch: true */
+
+  /* webpackChunkName: 'Bar' */
+  \\"./Foo\\")]).then(proms => proms[0]),
+  path: () => _path2.default.join(__dirname, \\"./Foo\\"),
+  resolve: () => require.resolveWeak(\\"./Foo\\"),
+  chunkName: () => \\"Bar\\"
+});
+"
+`;
+
+exports[`existing chunkName + webpackPreload 1`] = `
+"
+import(
+  /* webpackChunkName: 'Bar'*/
+  /* webpackPreload: true */
+  \\"./Foo\\")
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+var _path2 = _interopRequireDefault(require(\\"path\\"));
+
+var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+(0, _universalImport2.default)({
+  id: \\"./Foo\\",
+  load: () => Promise.all([import(
+  /* webpackPreload: true */
+
+  /* webpackChunkName: 'Bar' */
+  \\"./Foo\\")]).then(proms => proms[0]),
+  path: () => _path2.default.join(__dirname, \\"./Foo\\"),
+  resolve: () => require.resolveWeak(\\"./Foo\\"),
+  chunkName: () => \\"Bar\\"
+});
+"
+`;
+
+exports[`existing chunkName + webpackmode + webpackInclude + webpackExclude + webpackIgnore 1`] = `
+"
+import(
+  /* webpackChunkName: 'Bar'*/
+  /* webpackMode: \\"Lazy\\" */
+  /* webpackInclude: /*.js$/ */
+  /* webpackExclude: /(?!*test.js)$/ */
+  /* webpackIgnore: true */
+  \\"./Foo\\")
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+var _path2 = _interopRequireDefault(require(\\"path\\"));
+
+var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+(0, _universalImport2.default)({
+  id: \\"./Foo\\",
+  load: () => Promise.all([import(
+  /* webpackIgnore: true */
+
+  /* webpackExclude: /(?!*test.js)$/ */
+
+  /* webpackInclude: /*.js$/ */
+
+  /* webpackMode: \\"Lazy\\" */
+
+  /* webpackChunkName: 'Bar' */
+  \\"./Foo\\")]).then(proms => proms[0]),
+  path: () => _path2.default.join(__dirname, \\"./Foo\\"),
+  resolve: () => require.resolveWeak(\\"./Foo\\"),
+  chunkName: () => \\"Bar\\"
+});
+"
+`;
+
+exports[`existing chunkName + webpackmode + webpackInclude + webpackExclude 1`] = `
+"
+import(
+  /* webpackChunkName: 'Bar'*/
+  /* webpackMode: \\"Lazy\\" */
+  /* webpackInclude: /*.js$/ */
+  /* webpackExclude: /(?!*test.js)$/ */
+  \\"./Foo\\")
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+var _path2 = _interopRequireDefault(require(\\"path\\"));
+
+var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+(0, _universalImport2.default)({
+  id: \\"./Foo\\",
+  load: () => Promise.all([import(
+  /* webpackExclude: /(?!*test.js)$/ */
+
+  /* webpackInclude: /*.js$/ */
+
+  /* webpackMode: \\"Lazy\\" */
+
+  /* webpackChunkName: 'Bar' */
+  \\"./Foo\\")]).then(proms => proms[0]),
+  path: () => _path2.default.join(__dirname, \\"./Foo\\"),
+  resolve: () => require.resolveWeak(\\"./Foo\\"),
+  chunkName: () => \\"Bar\\"
+});
+"
+`;
+
+exports[`existing chunkName + webpackmode + webpackInclude 1`] = `
+"
+import(
+  /* webpackChunkName: 'Bar'*/
+  /* webpackMode: \\"Lazy\\" */
+  /* webpackInclude: /*.js$/ */
+  \\"./Foo\\")
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+var _path2 = _interopRequireDefault(require(\\"path\\"));
+
+var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+(0, _universalImport2.default)({
+  id: \\"./Foo\\",
+  load: () => Promise.all([import(
+  /* webpackInclude: /*.js$/ */
+
+  /* webpackMode: \\"Lazy\\" */
+
+  /* webpackChunkName: 'Bar' */
+  \\"./Foo\\")]).then(proms => proms[0]),
+  path: () => _path2.default.join(__dirname, \\"./Foo\\"),
+  resolve: () => require.resolveWeak(\\"./Foo\\"),
+  chunkName: () => \\"Bar\\"
+});
+"
+`;
+
+exports[`existing chunkName + webpackmode 1`] = `
+"
+import(/* webpackChunkName: 'Bar'*//* webpackMode: \\"Lazy\\" */\\"./Foo\\")
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+var _path2 = _interopRequireDefault(require(\\"path\\"));
+
+var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+(0, _universalImport2.default)({
+  id: \\"./Foo\\",
+  load: () => Promise.all([import(
+  /* webpackMode: \\"Lazy\\" */
+
+  /* webpackChunkName: 'Bar' */
+  \\"./Foo\\")]).then(proms => proms[0]),
+  path: () => _path2.default.join(__dirname, \\"./Foo\\"),
+  resolve: () => require.resolveWeak(\\"./Foo\\"),
+  chunkName: () => \\"Bar\\"
+});
+"
+`;
+
 exports[`existing chunkName 1`] = `
 "
 import(/* webpackChunkName: 'Bar' */\\"./Foo\\")
@@ -245,6 +462,192 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
   path: () => _path4.default.join(__dirname, \\"three\\"),
   resolve: () => require.resolveWeak(\\"three\\"),
   chunkName: () => \\"three\\"
+});
+"
+`;
+
+exports[`no chunkName + webpackPrefetch 1`] = `
+"
+import(
+  /* webpackPrefetch: true */
+  \\"./Foo\\")
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+var _path2 = _interopRequireDefault(require(\\"path\\"));
+
+var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+(0, _universalImport2.default)({
+  id: \\"./Foo\\",
+  load: () => Promise.all([import(
+  /* webpackPrefetch: true */
+
+  /* webpackChunkName: 'Foo' */
+  \\"./Foo\\")]).then(proms => proms[0]),
+  path: () => _path2.default.join(__dirname, \\"./Foo\\"),
+  resolve: () => require.resolveWeak(\\"./Foo\\"),
+  chunkName: () => \\"Foo\\"
+});
+"
+`;
+
+exports[`no chunkName + webpackPreload 1`] = `
+"
+import(
+  /* webpackPreload: true */
+  \\"./Foo\\")
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+var _path2 = _interopRequireDefault(require(\\"path\\"));
+
+var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+(0, _universalImport2.default)({
+  id: \\"./Foo\\",
+  load: () => Promise.all([import(
+  /* webpackPreload: true */
+
+  /* webpackChunkName: 'Foo' */
+  \\"./Foo\\")]).then(proms => proms[0]),
+  path: () => _path2.default.join(__dirname, \\"./Foo\\"),
+  resolve: () => require.resolveWeak(\\"./Foo\\"),
+  chunkName: () => \\"Foo\\"
+});
+"
+`;
+
+exports[`no chunkName + webpackmode + webpackInclude + webpackExclude + webpackIgnore 1`] = `
+"
+import(
+  /* webpackMode: \\"Lazy\\" */
+  /* webpackInclude: /*.js$/ */
+  /* webpackExclude: /(?!*test.js)$/ */
+  /* webpackIgnore: true */
+  \\"./Foo\\")
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+var _path2 = _interopRequireDefault(require(\\"path\\"));
+
+var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+(0, _universalImport2.default)({
+  id: \\"./Foo\\",
+  load: () => Promise.all([import(
+  /* webpackIgnore: true */
+
+  /* webpackExclude: /(?!*test.js)$/ */
+
+  /* webpackInclude: /*.js$/ */
+
+  /* webpackMode: \\"Lazy\\" */
+
+  /* webpackChunkName: 'Foo' */
+  \\"./Foo\\")]).then(proms => proms[0]),
+  path: () => _path2.default.join(__dirname, \\"./Foo\\"),
+  resolve: () => require.resolveWeak(\\"./Foo\\"),
+  chunkName: () => \\"Foo\\"
+});
+"
+`;
+
+exports[`no chunkName + webpackmode + webpackInclude + webpackExclude 1`] = `
+"
+import(
+  /* webpackMode: \\"Lazy\\" */
+  /* webpackInclude: /*.js$/ */
+  /* webpackExclude: /(?!*test.js)$/ */
+  \\"./Foo\\")
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+var _path2 = _interopRequireDefault(require(\\"path\\"));
+
+var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+(0, _universalImport2.default)({
+  id: \\"./Foo\\",
+  load: () => Promise.all([import(
+  /* webpackExclude: /(?!*test.js)$/ */
+
+  /* webpackInclude: /*.js$/ */
+
+  /* webpackMode: \\"Lazy\\" */
+
+  /* webpackChunkName: 'Foo' */
+  \\"./Foo\\")]).then(proms => proms[0]),
+  path: () => _path2.default.join(__dirname, \\"./Foo\\"),
+  resolve: () => require.resolveWeak(\\"./Foo\\"),
+  chunkName: () => \\"Foo\\"
+});
+"
+`;
+
+exports[`no chunkName + webpackmode + webpackInclude 1`] = `
+"
+import(
+  /* webpackMode: \\"Lazy\\" */
+  /* webpackInclude: /*.js$/ */
+  \\"./Foo\\")
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+var _path2 = _interopRequireDefault(require(\\"path\\"));
+
+var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+(0, _universalImport2.default)({
+  id: \\"./Foo\\",
+  load: () => Promise.all([import(
+  /* webpackInclude: /*.js$/ */
+
+  /* webpackMode: \\"Lazy\\" */
+
+  /* webpackChunkName: 'Foo' */
+  \\"./Foo\\")]).then(proms => proms[0]),
+  path: () => _path2.default.join(__dirname, \\"./Foo\\"),
+  resolve: () => require.resolveWeak(\\"./Foo\\"),
+  chunkName: () => \\"Foo\\"
+});
+"
+`;
+
+exports[`no chunkName + webpackmode 1`] = `
+"
+import(
+  /* webpackMode: \\"Lazy\\" */
+  \\"./Foo\\")
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+var _path2 = _interopRequireDefault(require(\\"path\\"));
+
+var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+(0, _universalImport2.default)({
+  id: \\"./Foo\\",
+  load: () => Promise.all([import(
+  /* webpackMode: \\"Lazy\\" */
+
+  /* webpackChunkName: 'Foo' */
+  \\"./Foo\\")]).then(proms => proms[0]),
+  path: () => _path2.default.join(__dirname, \\"./Foo\\"),
+  resolve: () => require.resolveWeak(\\"./Foo\\"),
+  chunkName: () => \\"Foo\\"
 });
 "
 `;

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -51,7 +51,75 @@ pluginTester({
       pluginOptions: { disableWarnings: true }
     },
     'existing chunkName': 'import(/* webpackChunkName: \'Bar\' */"./Foo")',
-    'multiple imports': 'import("one"); import("two"); import("three");'
+    'multiple imports': 'import("one"); import("two"); import("three");',
+    'existing chunkName + webpackmode': `import(/* webpackChunkName: 'Bar'*//* webpackMode: "Lazy" */"./Foo")`,
+    'existing chunkName + webpackmode + webpackInclude': `
+      import(
+        /* webpackChunkName: 'Bar'*/
+        /* webpackMode: "Lazy" */
+        /* webpackInclude: /*.js$/ */
+        "./Foo")`,
+    'existing chunkName + webpackmode + webpackInclude + webpackExclude': `
+      import(
+        /* webpackChunkName: 'Bar'*/
+        /* webpackMode: "Lazy" */
+        /* webpackInclude: /*.js$/ */
+        /* webpackExclude: /(?!*test.js)$/ */
+        "./Foo")`,
+    'existing chunkName + webpackmode + webpackInclude + webpackExclude + webpackIgnore': `
+      import(
+        /* webpackChunkName: 'Bar'*/
+        /* webpackMode: "Lazy" */
+        /* webpackInclude: /*.js$/ */
+        /* webpackExclude: /(?!*test.js)$/ */
+        /* webpackIgnore: true */
+        "./Foo")`,
+    'existing chunkName + strips out unknown things': `
+      import(
+        /* webpackFakeProperty1: "Lazy" */
+        /* webpackChunkName: 'Bar'*/
+        /* webpackFakeProperty3123: /foobar/ */
+        "./Foo")`,
+    'no chunkName + webpackmode + webpackInclude + webpackExclude + webpackIgnore': `
+      import(
+        /* webpackMode: "Lazy" */
+        /* webpackInclude: /*.js$/ */
+        /* webpackExclude: /(?!*test.js)$/ */
+        /* webpackIgnore: true */
+        "./Foo")`,
+    'no chunkName + webpackmode + webpackInclude + webpackExclude': `
+      import(
+        /* webpackMode: "Lazy" */
+        /* webpackInclude: /*.js$/ */
+        /* webpackExclude: /(?!*test.js)$/ */
+        "./Foo")`,
+    'no chunkName + webpackmode + webpackInclude': `
+      import(
+        /* webpackMode: "Lazy" */
+        /* webpackInclude: /*.js$/ */
+        "./Foo")`,
+    'no chunkName + webpackmode': `
+      import(
+        /* webpackMode: "Lazy" */
+        "./Foo")`,
+    'no chunkName + webpackPreload': `
+      import(
+        /* webpackPreload: true */
+        "./Foo")`,
+    'no chunkName + webpackPrefetch': `
+      import(
+        /* webpackPrefetch: true */
+        "./Foo")`,
+    'existing chunkName + webpackPreload': `
+      import(
+        /* webpackChunkName: 'Bar'*/
+        /* webpackPreload: true */
+        "./Foo")`,
+    'existing chunkName + webpackPrefetch': `
+      import(
+        /* webpackChunkName: 'Bar'*/
+        /* webpackPrefetch: true */
+        "./Foo")`
   }
 })
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,11 @@
   "peerDependencies": {
     "webpack": "^4.4.0"
   },
+  "jest": {
+    "testMatch": [
+      "**/?(*.)(spec|test).js?(x)"
+    ]
+  },
   "config": {
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"


### PR DESCRIPTION
Adds support for the following webpack magic strings that can be specified per comment block.

- `webpackMode`
- `webpackInclude`
- `webpackExclude`
- `webpackIgnore`
- `webpackPreload`
- `webpackPrefetch`

Also...
- [x] Updates docs
- [x] Updates tests & snapshots 
- [x] Update eslint rule to allow template strings