### PR TITLE
feat: Removing babel chunkname renaming

### DIFF
--- a/__tests__/__snapshots__/index.test.js.snap
+++ b/__tests__/__snapshots__/index.test.js.snap
@@ -130,7 +130,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
   \`./base/\${page}/nested/{$another}folder\`)]).then(proms => proms[0]),
   path: () => _path2.default.join(__dirname, \`./base/\${page}/nested/{$another}folder\`),
   resolve: () => require.resolveWeak(\`./base/\${page}/nested/{$another}folder\`),
-  chunkName: () => \`base/\${page}-nested-{$another}folder\`
+  chunkName: () => \`base/\${page}/nested/{$another}folder\`
 });
 "
 `;
@@ -154,7 +154,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
   \`./base/\${page}/nested/folder\`)]).then(proms => proms[0]),
   path: () => _path2.default.join(__dirname, \`./base/\${page}/nested/folder\`),
   resolve: () => require.resolveWeak(\`./base/\${page}/nested/folder\`),
-  chunkName: () => \`base/\${page}-nested-folder\`
+  chunkName: () => \`base/\${page}/nested/folder\`
 });
 "
 `;
@@ -668,11 +668,11 @@ const obj = {
   component: () => (0, _universalImport2.default)({
     id: \\"../components/nestedComponent\\",
     load: () => Promise.all([import(
-    /* webpackChunkName: 'components-nestedComponent' */
+    /* webpackChunkName: 'components/nestedComponent' */
     \`../components/nestedComponent\`)]).then(proms => proms[0]),
     path: () => _path2.default.join(__dirname, \`../components/nestedComponent\`),
     resolve: () => require.resolveWeak(\`../components/nestedComponent\`),
-    chunkName: () => \\"components-nestedComponent\\"
+    chunkName: () => \`components/nestedComponent\`
   })
 };
 
@@ -695,11 +695,11 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 (0, _universalImport2.default)({
   id: \\"../components/nestedComponent\\",
   load: () => Promise.all([import(
-  /* webpackChunkName: 'components-nestedComponent' */
+  /* webpackChunkName: 'components/nestedComponent' */
   \`../components/nestedComponent\`)]).then(proms => proms[0]),
   path: () => _path2.default.join(__dirname, \`../components/nestedComponent\`),
   resolve: () => require.resolveWeak(\`../components/nestedComponent\`),
-  chunkName: () => \\"components-nestedComponent\\"
+  chunkName: () => \`components/nestedComponent\`
 });
 "
 `;

--- a/index.js
+++ b/index.js
@@ -36,10 +36,6 @@ function trimChunkNameBaseDir(baseDir) {
   return baseDir.replace(/^[./]+|(\.js$)/g, '')
 }
 
-function prepareChunkNamePath(path) {
-  return path.replace(/\//g, '-')
-}
-
 function getImport(p, { source, nameHint }) {
   return addDefault(p, source, { nameHint })
 }
@@ -64,10 +60,8 @@ function createTrimmedChunkName(t, importArgNode) {
 }
 
 function prepareQuasi(quasi) {
-  const newPath = prepareChunkNamePath(quasi.value.cooked)
-
   return Object.assign({}, quasi, {
-    value: { raw: newPath, cooked: newPath }
+    value: { raw: quasi.value.cooked, cooked: quasi.value.cooked }
   })
 }
 
@@ -200,14 +194,6 @@ function chunkNameOption(t, chunkNameTemplate, importArgNode) {
   return t.objectProperty(t.identifier('chunkName'), chunkName)
 }
 
-function checkForNestedChunkName(node) {
-  const generatedChunkName = getMagicCommentChunkName(node)
-  const isNested =
-    generatedChunkName.indexOf('[request]') === -1 &&
-    generatedChunkName.indexOf('/') > -1
-  return isNested && prepareChunkNamePath(generatedChunkName)
-}
-
 module.exports = function universalImportPlugin({ types: t, template }) {
   const chunkNameTemplate = template('() => MODULE')
   const pathTemplate = template('() => PATH.join(__dirname, MODULE)')
@@ -226,9 +212,7 @@ module.exports = function universalImportPlugin({ types: t, template }) {
         const importArgNode = getImportArgPath(p).node
         t.existingChunkName = existingMagicCommentChunkName(importArgNode)
         // no existing chunkname, no problem - we will reuse that for fixing nested chunk names
-        if (!t.existingChunkName) {
-          t.existingChunkName = checkForNestedChunkName(importArgNode)
-        }
+
         const universalImport = getImport(p, IMPORT_UNIVERSAL_DEFAULT)
 
         // if being used in an await statement, return load() promise


### PR DESCRIPTION
This plugin will no longer rename chunks to replace slashes with dashes

BREAKING CHANGE: The plugin will no longer rename chunks to dashes