### PR TITLE
fix: do not add module "react-universal-component" into the webpack build if it has not been used explicilty in the app

### DIFF
--- a/universalImport.js
+++ b/universalImport.js
@@ -29,7 +29,8 @@ function setHasPlugin() {
       var weakId = require.resolveWeak('react-universal-component')
       universal = __webpack_require__(weakId)
     } else {
-      universal = module.require('react-universal-component')
+      var nodeRequire = typeof __non_webpack_require__ === 'undefined' ? require : __non_webpack_require__
+      universal = nodeRequire('react-universal-component')
     }
 
     if (universal) {


### PR DESCRIPTION
previously "react-universal-component" were always added to bundle for webpack@4.16.2+
because webpack started to treat "module.require" as normal "require" - https://github.com/webpack/webpack/releases/tag/v4.16.2 