### PR TITLE
fix: Webpack "Flush Chunks" error

### DIFF
--- a/universalImport.js
+++ b/universalImport.js
@@ -29,8 +29,11 @@ function setHasPlugin() {
       var weakId = require.resolveWeak('react-universal-component')
       universal = __webpack_require__(weakId)
     } else {
-      var nodeRequire = typeof __non_webpack_require__ === 'undefined' ? module.require : __non_webpack_require__
-      universal = nodeRequire('react-universal-component')
+      if (typeof __non_webpack_require__ === 'undefined') {
+        universal = module.require('react-universal-component')
+      } else {
+        universal = __non_webpack_require__('react-universal-component')
+      }
     }
 
     if (universal) {


### PR DESCRIPTION
Webpack only recognize require statement by the pattern `require(expression)` in code.
Referencing `require` function breaks Webpack chunk discovery and causes this error:

```
[FLUSH CHUNKS]: Unable to find default in Webpack chunks. Please check usage of Babel plugin.
```