### PR TITLE
feat: add support for Webpack 5

### DIFF
--- a/__tests__/__snapshots__/index.test.js.snap
+++ b/__tests__/__snapshots__/index.test.js.snap
@@ -24,7 +24,7 @@ import(\\"./Foo\\")
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path2 = _interopRequireDefault(require(\\"path\\"));
+var _pathBrowserify = _interopRequireDefault(require(\\"path-browserify\\"));
 
 var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
 
@@ -32,7 +32,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 (0, _universalImport2.default)({
   id: \\"./Foo\\",
-  path: () => _path2.default.join(__dirname, \\"./Foo\\"),
+  path: () => _pathBrowserify.default.join(__dirname, \\"./Foo\\"),
   resolve: () => require.resolveWeak(\\"./Foo\\"),
   chunkName: () => \\"Foo\\"
 });
@@ -45,7 +45,7 @@ import(\\"./Foo\\")
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path2 = _interopRequireDefault(require(\\"path\\"));
+var _pathBrowserify = _interopRequireDefault(require(\\"path-browserify\\"));
 
 var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
 
@@ -56,7 +56,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
   load: () => Promise.all([import(
   /* webpackChunkName: 'Foo' */
   \\"./Foo\\")]).then(proms => proms[0]),
-  path: () => _path2.default.join(__dirname, \\"./Foo\\"),
+  path: () => _pathBrowserify.default.join(__dirname, \\"./Foo\\"),
   resolve: () => require.resolveWeak(\\"./Foo\\"),
   chunkName: () => \\"Foo\\"
 });
@@ -69,7 +69,7 @@ import(\`../../base/\${page}\`)
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path2 = _interopRequireDefault(require(\\"path\\"));
+var _pathBrowserify = _interopRequireDefault(require(\\"path-browserify\\"));
 
 var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
 
@@ -80,7 +80,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
   load: () => Promise.all([import(
   /* webpackChunkName: 'base/[request]' */
   \`../../base/\${page}\`)]).then(proms => proms[0]),
-  path: () => _path2.default.join(__dirname, \`../../base/\${page}\`),
+  path: () => _pathBrowserify.default.join(__dirname, \`../../base/\${page}\`),
   resolve: () => require.resolveWeak(\`../../base/\${page}\`),
   chunkName: () => \`base/\${page}\`
 });
@@ -93,7 +93,7 @@ import(\`./\${page}\`)
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path2 = _interopRequireDefault(require(\\"path\\"));
+var _pathBrowserify = _interopRequireDefault(require(\\"path-browserify\\"));
 
 var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
 
@@ -104,7 +104,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
   load: () => Promise.all([import(
   /* webpackChunkName: '[request]' */
   \`./\${page}\`)]).then(proms => proms[0]),
-  path: () => _path2.default.join(__dirname, \`./\${page}\`),
+  path: () => _pathBrowserify.default.join(__dirname, \`./\${page}\`),
   resolve: () => require.resolveWeak(\`./\${page}\`),
   chunkName: () => \`\${page}\`
 });
@@ -117,7 +117,7 @@ import(\`./base/\${page}/nested/{$another}folder\`)
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path2 = _interopRequireDefault(require(\\"path\\"));
+var _pathBrowserify = _interopRequireDefault(require(\\"path-browserify\\"));
 
 var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
 
@@ -128,7 +128,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
   load: () => Promise.all([import(
   /* webpackChunkName: 'base/[request]' */
   \`./base/\${page}/nested/{$another}folder\`)]).then(proms => proms[0]),
-  path: () => _path2.default.join(__dirname, \`./base/\${page}/nested/{$another}folder\`),
+  path: () => _pathBrowserify.default.join(__dirname, \`./base/\${page}/nested/{$another}folder\`),
   resolve: () => require.resolveWeak(\`./base/\${page}/nested/{$another}folder\`),
   chunkName: () => \`base/\${page}/nested/{$another}folder\`
 });
@@ -141,7 +141,7 @@ import(\`./base/\${page}/nested/folder\`)
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path2 = _interopRequireDefault(require(\\"path\\"));
+var _pathBrowserify = _interopRequireDefault(require(\\"path-browserify\\"));
 
 var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
 
@@ -152,7 +152,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
   load: () => Promise.all([import(
   /* webpackChunkName: 'base/[request]' */
   \`./base/\${page}/nested/folder\`)]).then(proms => proms[0]),
-  path: () => _path2.default.join(__dirname, \`./base/\${page}/nested/folder\`),
+  path: () => _pathBrowserify.default.join(__dirname, \`./base/\${page}/nested/folder\`),
   resolve: () => require.resolveWeak(\`./base/\${page}/nested/folder\`),
   chunkName: () => \`base/\${page}/nested/folder\`
 });
@@ -165,7 +165,7 @@ import(\`./base/\${page}\`)
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path2 = _interopRequireDefault(require(\\"path\\"));
+var _pathBrowserify = _interopRequireDefault(require(\\"path-browserify\\"));
 
 var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
 
@@ -176,7 +176,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
   load: () => Promise.all([import(
   /* webpackChunkName: 'base/[request]' */
   \`./base/\${page}\`)]).then(proms => proms[0]),
-  path: () => _path2.default.join(__dirname, \`./base/\${page}\`),
+  path: () => _pathBrowserify.default.join(__dirname, \`./base/\${page}\`),
   resolve: () => require.resolveWeak(\`./base/\${page}\`),
   chunkName: () => \`base/\${page}\`
 });
@@ -193,7 +193,7 @@ import(
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path2 = _interopRequireDefault(require(\\"path\\"));
+var _pathBrowserify = _interopRequireDefault(require(\\"path-browserify\\"));
 
 var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
 
@@ -204,7 +204,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
   load: () => Promise.all([import(
   /* webpackChunkName: 'Foo' */
   \\"./Foo\\")]).then(proms => proms[0]),
-  path: () => _path2.default.join(__dirname, \\"./Foo\\"),
+  path: () => _pathBrowserify.default.join(__dirname, \\"./Foo\\"),
   resolve: () => require.resolveWeak(\\"./Foo\\"),
   chunkName: () => \\"Foo\\"
 });
@@ -220,7 +220,7 @@ import(
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path2 = _interopRequireDefault(require(\\"path\\"));
+var _pathBrowserify = _interopRequireDefault(require(\\"path-browserify\\"));
 
 var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
 
@@ -233,7 +233,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
   /* webpackChunkName: 'Bar' */
   \\"./Foo\\")]).then(proms => proms[0]),
-  path: () => _path2.default.join(__dirname, \\"./Foo\\"),
+  path: () => _pathBrowserify.default.join(__dirname, \\"./Foo\\"),
   resolve: () => require.resolveWeak(\\"./Foo\\"),
   chunkName: () => \\"Bar\\"
 });
@@ -249,7 +249,7 @@ import(
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path2 = _interopRequireDefault(require(\\"path\\"));
+var _pathBrowserify = _interopRequireDefault(require(\\"path-browserify\\"));
 
 var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
 
@@ -262,7 +262,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
   /* webpackChunkName: 'Bar' */
   \\"./Foo\\")]).then(proms => proms[0]),
-  path: () => _path2.default.join(__dirname, \\"./Foo\\"),
+  path: () => _pathBrowserify.default.join(__dirname, \\"./Foo\\"),
   resolve: () => require.resolveWeak(\\"./Foo\\"),
   chunkName: () => \\"Bar\\"
 });
@@ -281,7 +281,7 @@ import(
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path2 = _interopRequireDefault(require(\\"path\\"));
+var _pathBrowserify = _interopRequireDefault(require(\\"path-browserify\\"));
 
 var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
 
@@ -300,7 +300,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
   /* webpackChunkName: 'Bar' */
   \\"./Foo\\")]).then(proms => proms[0]),
-  path: () => _path2.default.join(__dirname, \\"./Foo\\"),
+  path: () => _pathBrowserify.default.join(__dirname, \\"./Foo\\"),
   resolve: () => require.resolveWeak(\\"./Foo\\"),
   chunkName: () => \\"Bar\\"
 });
@@ -318,7 +318,7 @@ import(
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path2 = _interopRequireDefault(require(\\"path\\"));
+var _pathBrowserify = _interopRequireDefault(require(\\"path-browserify\\"));
 
 var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
 
@@ -335,7 +335,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
   /* webpackChunkName: 'Bar' */
   \\"./Foo\\")]).then(proms => proms[0]),
-  path: () => _path2.default.join(__dirname, \\"./Foo\\"),
+  path: () => _pathBrowserify.default.join(__dirname, \\"./Foo\\"),
   resolve: () => require.resolveWeak(\\"./Foo\\"),
   chunkName: () => \\"Bar\\"
 });
@@ -352,7 +352,7 @@ import(
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path2 = _interopRequireDefault(require(\\"path\\"));
+var _pathBrowserify = _interopRequireDefault(require(\\"path-browserify\\"));
 
 var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
 
@@ -367,7 +367,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
   /* webpackChunkName: 'Bar' */
   \\"./Foo\\")]).then(proms => proms[0]),
-  path: () => _path2.default.join(__dirname, \\"./Foo\\"),
+  path: () => _pathBrowserify.default.join(__dirname, \\"./Foo\\"),
   resolve: () => require.resolveWeak(\\"./Foo\\"),
   chunkName: () => \\"Bar\\"
 });
@@ -380,7 +380,7 @@ import(/* webpackChunkName: 'Bar'*//* webpackMode: \\"Lazy\\" */\\"./Foo\\")
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path2 = _interopRequireDefault(require(\\"path\\"));
+var _pathBrowserify = _interopRequireDefault(require(\\"path-browserify\\"));
 
 var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
 
@@ -393,7 +393,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
   /* webpackChunkName: 'Bar' */
   \\"./Foo\\")]).then(proms => proms[0]),
-  path: () => _path2.default.join(__dirname, \\"./Foo\\"),
+  path: () => _pathBrowserify.default.join(__dirname, \\"./Foo\\"),
   resolve: () => require.resolveWeak(\\"./Foo\\"),
   chunkName: () => \\"Bar\\"
 });
@@ -406,7 +406,7 @@ import(/* webpackChunkName: 'Bar' */\\"./Foo\\")
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path2 = _interopRequireDefault(require(\\"path\\"));
+var _pathBrowserify = _interopRequireDefault(require(\\"path-browserify\\"));
 
 var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
 
@@ -417,7 +417,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
   load: () => Promise.all([import(
   /* webpackChunkName: 'Bar' */
   \\"./Foo\\")]).then(proms => proms[0]),
-  path: () => _path2.default.join(__dirname, \\"./Foo\\"),
+  path: () => _pathBrowserify.default.join(__dirname, \\"./Foo\\"),
   resolve: () => require.resolveWeak(\\"./Foo\\"),
   chunkName: () => \\"Bar\\"
 });
@@ -430,7 +430,7 @@ import(\\"one\\"); import(\\"two\\"); import(\\"three\\");
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path4 = _interopRequireDefault(require(\\"path\\"));
+var _pathBrowserify = _interopRequireDefault(require(\\"path-browserify\\"));
 
 var _universalImport4 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
 
@@ -441,7 +441,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
   load: () => Promise.all([import(
   /* webpackChunkName: 'one' */
   \\"one\\")]).then(proms => proms[0]),
-  path: () => _path4.default.join(__dirname, \\"one\\"),
+  path: () => _pathBrowserify.default.join(__dirname, \\"one\\"),
   resolve: () => require.resolveWeak(\\"one\\"),
   chunkName: () => \\"one\\"
 });
@@ -450,7 +450,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
   load: () => Promise.all([import(
   /* webpackChunkName: 'two' */
   \\"two\\")]).then(proms => proms[0]),
-  path: () => _path4.default.join(__dirname, \\"two\\"),
+  path: () => _pathBrowserify.default.join(__dirname, \\"two\\"),
   resolve: () => require.resolveWeak(\\"two\\"),
   chunkName: () => \\"two\\"
 });
@@ -459,7 +459,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
   load: () => Promise.all([import(
   /* webpackChunkName: 'three' */
   \\"three\\")]).then(proms => proms[0]),
-  path: () => _path4.default.join(__dirname, \\"three\\"),
+  path: () => _pathBrowserify.default.join(__dirname, \\"three\\"),
   resolve: () => require.resolveWeak(\\"three\\"),
   chunkName: () => \\"three\\"
 });
@@ -474,7 +474,7 @@ import(
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path2 = _interopRequireDefault(require(\\"path\\"));
+var _pathBrowserify = _interopRequireDefault(require(\\"path-browserify\\"));
 
 var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
 
@@ -487,7 +487,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
   /* webpackChunkName: 'Foo' */
   \\"./Foo\\")]).then(proms => proms[0]),
-  path: () => _path2.default.join(__dirname, \\"./Foo\\"),
+  path: () => _pathBrowserify.default.join(__dirname, \\"./Foo\\"),
   resolve: () => require.resolveWeak(\\"./Foo\\"),
   chunkName: () => \\"Foo\\"
 });
@@ -502,7 +502,7 @@ import(
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path2 = _interopRequireDefault(require(\\"path\\"));
+var _pathBrowserify = _interopRequireDefault(require(\\"path-browserify\\"));
 
 var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
 
@@ -515,7 +515,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
   /* webpackChunkName: 'Foo' */
   \\"./Foo\\")]).then(proms => proms[0]),
-  path: () => _path2.default.join(__dirname, \\"./Foo\\"),
+  path: () => _pathBrowserify.default.join(__dirname, \\"./Foo\\"),
   resolve: () => require.resolveWeak(\\"./Foo\\"),
   chunkName: () => \\"Foo\\"
 });
@@ -533,7 +533,7 @@ import(
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path2 = _interopRequireDefault(require(\\"path\\"));
+var _pathBrowserify = _interopRequireDefault(require(\\"path-browserify\\"));
 
 var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
 
@@ -552,7 +552,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
   /* webpackChunkName: 'Foo' */
   \\"./Foo\\")]).then(proms => proms[0]),
-  path: () => _path2.default.join(__dirname, \\"./Foo\\"),
+  path: () => _pathBrowserify.default.join(__dirname, \\"./Foo\\"),
   resolve: () => require.resolveWeak(\\"./Foo\\"),
   chunkName: () => \\"Foo\\"
 });
@@ -569,7 +569,7 @@ import(
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path2 = _interopRequireDefault(require(\\"path\\"));
+var _pathBrowserify = _interopRequireDefault(require(\\"path-browserify\\"));
 
 var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
 
@@ -586,7 +586,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
   /* webpackChunkName: 'Foo' */
   \\"./Foo\\")]).then(proms => proms[0]),
-  path: () => _path2.default.join(__dirname, \\"./Foo\\"),
+  path: () => _pathBrowserify.default.join(__dirname, \\"./Foo\\"),
   resolve: () => require.resolveWeak(\\"./Foo\\"),
   chunkName: () => \\"Foo\\"
 });
@@ -602,7 +602,7 @@ import(
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path2 = _interopRequireDefault(require(\\"path\\"));
+var _pathBrowserify = _interopRequireDefault(require(\\"path-browserify\\"));
 
 var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
 
@@ -617,7 +617,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
   /* webpackChunkName: 'Foo' */
   \\"./Foo\\")]).then(proms => proms[0]),
-  path: () => _path2.default.join(__dirname, \\"./Foo\\"),
+  path: () => _pathBrowserify.default.join(__dirname, \\"./Foo\\"),
   resolve: () => require.resolveWeak(\\"./Foo\\"),
   chunkName: () => \\"Foo\\"
 });
@@ -632,7 +632,7 @@ import(
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path2 = _interopRequireDefault(require(\\"path\\"));
+var _pathBrowserify = _interopRequireDefault(require(\\"path-browserify\\"));
 
 var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
 
@@ -645,7 +645,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
   /* webpackChunkName: 'Foo' */
   \\"./Foo\\")]).then(proms => proms[0]),
-  path: () => _path2.default.join(__dirname, \\"./Foo\\"),
+  path: () => _pathBrowserify.default.join(__dirname, \\"./Foo\\"),
   resolve: () => require.resolveWeak(\\"./Foo\\"),
   chunkName: () => \\"Foo\\"
 });
@@ -658,7 +658,7 @@ const obj = {component:()=>import(\`../components/nestedComponent\`)}; ()=> obj.
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path2 = _interopRequireDefault(require(\\"path\\"));
+var _pathBrowserify = _interopRequireDefault(require(\\"path-browserify\\"));
 
 var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
 
@@ -670,7 +670,7 @@ const obj = {
     load: () => Promise.all([import(
     /* webpackChunkName: 'components/nestedComponent' */
     \`../components/nestedComponent\`)]).then(proms => proms[0]),
-    path: () => _path2.default.join(__dirname, \`../components/nestedComponent\`),
+    path: () => _pathBrowserify.default.join(__dirname, \`../components/nestedComponent\`),
     resolve: () => require.resolveWeak(\`../components/nestedComponent\`),
     chunkName: () => \`components/nestedComponent\`
   })
@@ -686,7 +686,7 @@ import(\`../components/nestedComponent\`)
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path2 = _interopRequireDefault(require(\\"path\\"));
+var _pathBrowserify = _interopRequireDefault(require(\\"path-browserify\\"));
 
 var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
 
@@ -697,7 +697,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
   load: () => Promise.all([import(
   /* webpackChunkName: 'components/nestedComponent' */
   \`../components/nestedComponent\`)]).then(proms => proms[0]),
-  path: () => _path2.default.join(__dirname, \`../components/nestedComponent\`),
+  path: () => _pathBrowserify.default.join(__dirname, \`../components/nestedComponent\`),
   resolve: () => require.resolveWeak(\`../components/nestedComponent\`),
   chunkName: () => \`components/nestedComponent\`
 });
@@ -710,7 +710,7 @@ import(\`../../base\`)
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path2 = _interopRequireDefault(require(\\"path\\"));
+var _pathBrowserify = _interopRequireDefault(require(\\"path-browserify\\"));
 
 var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
 
@@ -721,7 +721,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
   load: () => Promise.all([import(
   /* webpackChunkName: 'base' */
   \`../../base\`)]).then(proms => proms[0]),
-  path: () => _path2.default.join(__dirname, \`../../base\`),
+  path: () => _pathBrowserify.default.join(__dirname, \`../../base\`),
   resolve: () => require.resolveWeak(\`../../base\`),
   chunkName: () => \`base\`
 });
@@ -734,7 +734,7 @@ import(\`./base\`)
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path2 = _interopRequireDefault(require(\\"path\\"));
+var _pathBrowserify = _interopRequireDefault(require(\\"path-browserify\\"));
 
 var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
 
@@ -745,7 +745,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
   load: () => Promise.all([import(
   /* webpackChunkName: 'base' */
   \`./base\`)]).then(proms => proms[0]),
-  path: () => _path2.default.join(__dirname, \`./base\`),
+  path: () => _pathBrowserify.default.join(__dirname, \`./base\`),
   resolve: () => require.resolveWeak(\`./base\`),
   chunkName: () => \`base\`
 });
@@ -758,7 +758,7 @@ import(\\"./Foo.js\\")
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path2 = _interopRequireDefault(require(\\"path\\"));
+var _pathBrowserify = _interopRequireDefault(require(\\"path-browserify\\"));
 
 var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
 
@@ -769,7 +769,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
   load: () => Promise.all([import(
   /* webpackChunkName: 'Foo' */
   \\"./Foo.js\\")]).then(proms => proms[0]),
-  path: () => _path2.default.join(__dirname, \\"./Foo.js\\"),
+  path: () => _pathBrowserify.default.join(__dirname, \\"./Foo.js\\"),
   resolve: () => require.resolveWeak(\\"./Foo.js\\"),
   chunkName: () => \\"Foo\\"
 });
@@ -782,7 +782,7 @@ import(\\"../../Foo\\")
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path2 = _interopRequireDefault(require(\\"path\\"));
+var _pathBrowserify = _interopRequireDefault(require(\\"path-browserify\\"));
 
 var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
 
@@ -793,7 +793,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
   load: () => Promise.all([import(
   /* webpackChunkName: 'Foo' */
   \\"../../Foo\\")]).then(proms => proms[0]),
-  path: () => _path2.default.join(__dirname, \\"../../Foo\\"),
+  path: () => _pathBrowserify.default.join(__dirname, \\"../../Foo\\"),
   resolve: () => require.resolveWeak(\\"../../Foo\\"),
   chunkName: () => \\"Foo\\"
 });
@@ -806,7 +806,7 @@ import(\\"./Foo\\")
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-var _path2 = _interopRequireDefault(require(\\"path\\"));
+var _pathBrowserify = _interopRequireDefault(require(\\"path-browserify\\"));
 
 var _universalImport2 = _interopRequireDefault(require(\\"babel-plugin-universal-import/universalImport\\"));
 
@@ -817,7 +817,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
   load: () => Promise.all([import(
   /* webpackChunkName: 'Foo' */
   \\"./Foo\\")]).then(proms => proms[0]),
-  path: () => _path2.default.join(__dirname, \\"./Foo\\"),
+  path: () => _pathBrowserify.default.join(__dirname, \\"./Foo\\"),
   resolve: () => require.resolveWeak(\\"./Foo\\"),
   chunkName: () => \\"Foo\\"
 });

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ const IMPORT_UNIVERSAL_DEFAULT = {
 
 const IMPORT_PATH_DEFAULT = {
   id: Symbol('pathId'),
-  source: 'path',
+  source: 'path-browserify',
   nameHint: 'path'
 }
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "travis-github-status": "1.6.3"
   },
   "peerDependencies": {
-    "webpack": "^4.4.0"
+    "webpack": "^4.4.0 || ^5.0.0"
   },
   "jest": {
     "testMatch": [
@@ -83,6 +83,7 @@
     "verbose": true
   },
   "dependencies": {
-    "@babel/helper-module-imports": "^7.0.0"
+    "@babel/helper-module-imports": "^7.0.0",
+    "path-browserify": "^1.0.1"
   }
 }


### PR DESCRIPTION
Webpack 5 doesn't polyfill NodeJS modules anymore. This change replaces usage of NodeJS `path` with
`path-browserify`.

fix #142